### PR TITLE
Wrap Button in React.forwardRef

### DIFF
--- a/components/atoms/button/components/button.js
+++ b/components/atoms/button/components/button.js
@@ -3,6 +3,7 @@
  */
 
 // React
+import { forwardRef } from 'react'
 import { bool, func, node, number, objectOf, oneOf, oneOfType, string } from 'prop-types'
 
 // UI
@@ -11,13 +12,13 @@ import { BACKGROUND, CONTEXT, SHADE_COLOUR, SIZE } from '../../../'
 // Style
 import styled from 'styled-components'
 
-export const Button = (props) => {
+export const Button = forwardRef((props, ref) => {
   return (
-    <StyledButton {...props} role='button'>
+    <StyledButton {...props} ref={ref} role='button'>
       {props.children || props.content}
     </StyledButton>
   )
-}
+})
 
 const StyledButton = styled.button`
   ${props => BACKGROUND(props)}

--- a/components/atoms/link/__tests__/stories.js
+++ b/components/atoms/link/__tests__/stories.js
@@ -10,6 +10,7 @@ import { storiesOf } from '@storybook/react'
 
 // UI
 import { Link } from '../'
+import { Button } from '../../'
 import Readme from '../README.md'
 
 storiesOf('Atoms/Link', module)
@@ -22,4 +23,12 @@ storiesOf('Atoms/Link', module)
 
   .add('Default', () =>
     <Link to='/'><a>Home</a></Link>
+  )
+
+  .add('Button', () =>
+    <Link to='/'><button>Home</button></Link>
+  )
+
+  .add('Button component', () =>
+    <Link to='/'><Button>Home</Button></Link>
   )


### PR DESCRIPTION
When Next.js Link component has a React component as a child, the child component needs to be wrapped in `React.forwardRef`.