### PR TITLE
Apply cloneDeep to mock data

### DIFF
--- a/components/utils/mockHelpers.js
+++ b/components/utils/mockHelpers.js
@@ -1,6 +1,7 @@
 /**
  * Mock helpers
  */
+import cloneDeep from 'lodash/cloneDeep'
 
 // merge array with localStorage data
 export const mergeLocalData = (array, key) => {
@@ -17,7 +18,7 @@ export const mergeLocalData = (array, key) => {
       }
     })
   }
-  return array
+  return cloneDeep(array)
 }
 
 export const findByKey = (array, key, value) => {


### PR DESCRIPTION
Prevents `TypeError: Converting circular structure to JSON` errors in mock API requests