### PR TITLE
Improve authorization role checker

### DIFF
--- a/components/services/authorization/providers/authProvider.js
+++ b/components/services/authorization/providers/authProvider.js
@@ -57,7 +57,6 @@ export const AuthorizationProvider = ({ children }) => {
   const checkRole = role => {
     // check
     const [type, subtype] = role.split('_')
-    console.log('test', type, subtype)
 
     if (subtype) {
       switch (subtype) {

--- a/components/services/authorization/providers/authProvider.js
+++ b/components/services/authorization/providers/authProvider.js
@@ -54,9 +54,37 @@ export const AuthorizationProvider = ({ children }) => {
     }
   }
 
+  const checkRole = role => {
+    // check
+    const [type, subtype] = role.split('_')
+    console.log('test', type, subtype)
+
+    if (subtype) {
+      switch (subtype) {
+        case 'owner':
+          return user.role === type + '_owner'
+          break
+        case 'manager':
+          return user.role === type + '_owner' || user.role === type + '_manager'
+          break
+        case 'user':
+          return user.role.startsWith(type)
+          break
+        default:
+          return false
+      }
+    } else {
+      return user.role.startsWith(type)
+    }
+  }
+
   const hasRole = role => {
     if (user && user.role) {
-      return Array.isArray(role) ? role.includes(user.role) : user.role === role
+      if (Array.isArray(role)) {
+        return role.some(checkRole)
+      } else {
+        return checkRole(role)
+      }
     }
     return false
   }


### PR DESCRIPTION
Allows using main role type, e.g. `hasRole('admin')` to allow access to all subtype roles (user, manager, owner), without having to specify each one.