### PR TITLE
Messaging fixes

### DIFF
--- a/components/organisms/messaging/background/README.md
+++ b/components/organisms/messaging/background/README.md
@@ -1,1 +1,3 @@
 # Messaging/MessageBackground
+
+Provides a background for the messages, we have 3 examples here: Whatsapp, drykiss and blank background

--- a/components/organisms/messaging/background/__tests__/stories.js
+++ b/components/organisms/messaging/background/__tests__/stories.js
@@ -36,6 +36,4 @@ const options = {
 
 const defaultValue = '/messaging/background.png'
 
-export const main = () => <MessageBackground />
-
-export const path = () => <MessageBackground path={select('Background', options, defaultValue)} />
+export const main = () => <MessageBackground path={select('Background', options, defaultValue)} />

--- a/components/organisms/messaging/container/README.md
+++ b/components/organisms/messaging/container/README.md
@@ -1,1 +1,5 @@
 # Messaging/Container
+
+Provides an message container where we can find different examples of messages
+
+Feature also include messages being truncated by Height

--- a/components/organisms/messaging/container/__mocks__/messages.js
+++ b/components/organisms/messaging/container/__mocks__/messages.js
@@ -77,6 +77,18 @@ export const messages = [
     type: 'out'
   },
   {
+    content: 'Yes, I will do it. \n Line 2 \n Next line will be hidden. \n  Here is the line 4',
+    reply: 'Re: 5397 — PPM',
+    icon: 'email',
+    from: 'Mike <mike@xyz.com>',
+    to: 'internal',
+    pictureId: null,
+    statusText: 'delivered',
+    time: 'Mon 4 Nov 2019 13:45',
+    type: 'in',
+    more: true
+  },
+  {
     content: 'Job complete.',
     icon: 'notification',
     from: 'System message',

--- a/components/organisms/messaging/container/__mocks__/messages.js
+++ b/components/organisms/messaging/container/__mocks__/messages.js
@@ -77,18 +77,6 @@ export const messages = [
     type: 'out'
   },
   {
-    content: 'Yes, I will do it. \n Line 2 \n Next line will be hidden. \n  Here is the line 4',
-    reply: 'Re: 5397 — PPM',
-    icon: 'email',
-    from: 'Mike <mike@xyz.com>',
-    to: 'internal',
-    pictureId: null,
-    statusText: 'delivered',
-    time: 'Mon 4 Nov 2019 13:45',
-    type: 'in',
-    more: true
-  },
-  {
     content: 'Job complete.',
     icon: 'notification',
     from: 'System message',

--- a/components/organisms/messaging/container/__mocks__/messages.js
+++ b/components/organisms/messaging/container/__mocks__/messages.js
@@ -20,6 +20,19 @@ export const messages = [
     statusText: 'delivered',
     time: 'Mon 4 Nov 2019 11:59',
     type: 'in',
+    more: false
+  },
+  {
+    content:
+      'Hiya this is a message adding "Read more " where we are expecting a PPM scheduled maintenance check on our LED lightbulbs throughout the third floor of XYZ Company offices today.\n  Would appreciate a timely response on this so we can sort out security. \n Text hidden by See More',
+    reply: 'Re: 5397 — PPM',
+    icon: 'email',
+    from: 'Mike <mike@xyz.com>',
+    to: 'internal',
+    pictureId: null,
+    statusText: 'delivered',
+    time: 'Mon 4 Nov 2019 11:59',
+    type: 'in',
     more: true
   },
   {

--- a/components/organisms/messaging/container/__mocks__/messages.js
+++ b/components/organisms/messaging/container/__mocks__/messages.js
@@ -20,7 +20,7 @@ export const messages = [
     statusText: 'delivered',
     time: 'Mon 4 Nov 2019 11:59',
     type: 'in',
-    hasMore: true
+    more: true
   },
   {
     content: 'Late arrival.',

--- a/components/organisms/messaging/container/__mocks__/messages.js
+++ b/components/organisms/messaging/container/__mocks__/messages.js
@@ -20,7 +20,7 @@ export const messages = [
     statusText: 'delivered',
     time: 'Mon 4 Nov 2019 11:59',
     type: 'in',
-    more: true
+    hasMore: true
   },
   {
     content: 'Late arrival.',

--- a/components/organisms/messaging/container/__tests__/stories.js
+++ b/components/organisms/messaging/container/__tests__/stories.js
@@ -97,9 +97,9 @@ const BaseComponent = (props = {}) => {
     onFilter: change,
     onSearch: handleSearch,
     onSubmit: handleSubmit,
+    maxLength: 1200,
     ...props
   }
-
   return messaging && <MessagingContainer {...defaultProps} />
 }
 

--- a/components/organisms/messaging/container/__tests__/stories.js
+++ b/components/organisms/messaging/container/__tests__/stories.js
@@ -97,9 +97,9 @@ const BaseComponent = (props = {}) => {
     onFilter: change,
     onSearch: handleSearch,
     onSubmit: handleSubmit,
-    maxLength: 1200,
     ...props
   }
+
   return messaging && <MessagingContainer {...defaultProps} />
 }
 

--- a/components/organisms/messaging/container/__tests__/stories.js
+++ b/components/organisms/messaging/container/__tests__/stories.js
@@ -67,8 +67,7 @@ const BaseComponent = (props = {}) => {
       statusText: 'delivered',
       to: audience,
       type: type || 'out',
-      issueId: 1,
-      more: true
+      issueId: 1
     }
 
     msg.id = messaging[messaging.length - 1].id + 1

--- a/components/organisms/messaging/container/__tests__/stories.js
+++ b/components/organisms/messaging/container/__tests__/stories.js
@@ -67,7 +67,8 @@ const BaseComponent = (props = {}) => {
       statusText: 'delivered',
       to: audience,
       type: type || 'out',
-      issueId: 1
+      issueId: 1,
+      more: true
     }
 
     msg.id = messaging[messaging.length - 1].id + 1

--- a/components/organisms/messaging/messageBase/components/messageBase.js
+++ b/components/organisms/messaging/messageBase/components/messageBase.js
@@ -7,7 +7,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { string, bool } from 'prop-types'
 
 // UI
-import { Card, Column, Icon, Image, Row, Truncate } from '../../../../'
+import { Card, Column, Icon, Image, Row, TruncateByMaxHeight } from '../../../../'
 import { MessageIcon } from './icon'
 import { MessageTo } from './to'
 
@@ -108,7 +108,7 @@ const StyledCard = styled(Card)`
 
 const StyledContent = styled.div`
   color: #000;
-  ${({ seeMore }) => !seeMore && Truncate()}
+  ${({ seeMore }) => !seeMore && TruncateByMaxHeight('70px')}
 `
 
 const StyledReply = styled.div`

--- a/components/organisms/messaging/messageBase/components/messageBase.js
+++ b/components/organisms/messaging/messageBase/components/messageBase.js
@@ -35,6 +35,9 @@ export const MessageBase = ({
     if (scrollToMessage) messageRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
   }, [])
 
+  console.log('message seemore ', seeMore)
+  console.log('message more ', seeMore)
+
   return (
     <Column sm={11} columnRef={messageRef}>
       <StyledCard type={type}>
@@ -71,17 +74,17 @@ export const MessageBase = ({
                 })}
             </StyledContent>
 
-            {more && (
+            {true && (
               <StyledCollapse onClick={() => setSeeMore(!seeMore)}>
-                {!seeMore ? (
-                  <>
-                    <span>See more</span>
-                    <Icon icon='chevron-down' />
-                  </>
-                ) : (
+                {seeMore ? (
                   <>
                     <span>Close</span>
                     <Icon icon='chevron-up' />
+                  </>
+                ) : (
+                  <>
+                    <span>See more</span>
+                    <Icon icon='chevron-down' />
                   </>
                 )}
               </StyledCollapse>

--- a/components/organisms/messaging/messageBase/components/messageBase.js
+++ b/components/organisms/messaging/messageBase/components/messageBase.js
@@ -18,7 +18,7 @@ export const MessageBase = ({
   content,
   from,
   icon,
-  more,
+  hasMore,
   pictureId,
   prevType,
   reply,
@@ -36,7 +36,7 @@ export const MessageBase = ({
   }, [])
 
   console.log('message seemore ', seeMore)
-  console.log('message more ', seeMore)
+  console.log('message hasMore ', hasMore)
 
   return (
     <Column sm={11} columnRef={messageRef}>
@@ -74,7 +74,7 @@ export const MessageBase = ({
                 })}
             </StyledContent>
 
-            {true && (
+            {hasMore && (
               <StyledCollapse onClick={() => setSeeMore(!seeMore)}>
                 {seeMore ? (
                   <>

--- a/components/organisms/messaging/messageBase/components/messageBase.js
+++ b/components/organisms/messaging/messageBase/components/messageBase.js
@@ -18,7 +18,6 @@ export const MessageBase = ({
   content,
   from,
   icon,
-  hasMore,
   pictureId,
   prevType,
   reply,
@@ -26,6 +25,7 @@ export const MessageBase = ({
   statusText,
   time,
   to,
+  more,
   type
 }) => {
   const [seeMore, setSeeMore] = useState(false)
@@ -34,9 +34,6 @@ export const MessageBase = ({
   useEffect(() => {
     if (scrollToMessage) messageRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
   }, [])
-
-  console.log('message seemore ', seeMore)
-  console.log('message hasMore ', hasMore)
 
   return (
     <Column sm={11} columnRef={messageRef}>
@@ -74,7 +71,7 @@ export const MessageBase = ({
                 })}
             </StyledContent>
 
-            {hasMore && (
+            {more && (
               <StyledCollapse onClick={() => setSeeMore(!seeMore)}>
                 {seeMore ? (
                   <>

--- a/components/utils/truncate.js
+++ b/components/utils/truncate.js
@@ -4,12 +4,14 @@
  */
 export const Truncate = () => {
   return `
-  display: inline-block;
-  line-height: 1.4;
-  max-height: 70px;
-  overflow: hidden;
-  width: 100%;
-  word-wrap: break-word;
-  text-overflow: ellipsis;
+    display: inline-block;
+    line-height: initial;
+    overflow: hidden;
+    white-space: nowrap;
+    max-height: 70px;
+    width: 100%;
+    word-break: break-all;
+    word-wrap: break-word;
+    text-overflow: ellipsis;
   `
 }

--- a/components/utils/truncate.js
+++ b/components/utils/truncate.js
@@ -4,14 +4,26 @@
  */
 export const Truncate = () => {
   return `
+  display: inline-block;
+  line-height: initial;
+  overflow: hidden;
+  white-space: nowrap;
+  width: 100%;
+  word-break: break-all;
+  word-wrap: break-word;
+  text-overflow: ellipsis;
+  `
+}
+
+// TODO: This will be deprecated when we manage it directly in JS.
+export const TruncateByMaxHeight = maxHeight => {
+  return `
     display: inline-block;
-    line-height: initial;
+    line-height: 1.4;
     overflow: hidden;
-    white-space: nowrap;
-    max-height: 70px;
+    white-space: wrap;
+    max-height: ${maxHeight};
     width: 100%;
-    word-break: break-all;
-    word-wrap: break-word;
-    text-overflow: ellipsis;
+
   `
 }

--- a/components/utils/truncate.js
+++ b/components/utils/truncate.js
@@ -4,14 +4,12 @@
  */
 export const Truncate = () => {
   return `
-    display: inline-block;
-    line-height: initial;
-    overflow: hidden;
-    white-space: nowrap;
-    max-height: 70px;
-    width: 100%;
-    word-break: break-all;
-    word-wrap: break-word;
-    text-overflow: ellipsis;
+  display: inline-block;
+  line-height: 1.4;
+  max-height: 70px;
+  overflow: hidden;
+  width: 100%;
+  word-wrap: break-word;
+  text-overflow: ellipsis;
   `
 }

--- a/components/utils/truncate.js
+++ b/components/utils/truncate.js
@@ -8,6 +8,7 @@ export const Truncate = () => {
     line-height: initial;
     overflow: hidden;
     white-space: nowrap;
+    max-height: 70px;
     width: 100%;
     word-break: break-all;
     word-wrap: break-word;


### PR DESCRIPTION
[Messaging Fixes - Loom Video](https://www.loom.com/share/fbfa0ecc09c44d32a06b306e27be1c0a)
- New truncate method where we insert max-height so we can short by height, and wrapping lines without breaking words in the end of the line.
- Modified container story with one of the previous example and some readme modifications
- Deleted a redundant story for backgroundMessage
- SeeMore render is now asking in positive way to understand it better.

Keep in mind for future:
Consider to create the max-height being calculated by line-height + font-size + number lines we want to start to skip.
We will improve this getting a JS solution
We will have to make this max-height responsive being calculated automatically.

Note: MessageBackground need to be rechecked seems not working fine when I tried to create a story using it, we were using absolute/relative positions instead of flexbox solution.
