### PR TITLE
fix: make Login submit prop optional

### DIFF
--- a/components/organisms/login/login.js
+++ b/components/organisms/login/login.js
@@ -153,7 +153,7 @@ Login.propTypes = {
   blockSubmitButton: bool,
   forgotPassword: bool,
   heading: string,
-  submit: func.isRequired,
+  submit: func,
   pathForgot: string,
   pathSignUp: oneOfType([object, string]),
   remember: string,


### PR DESCRIPTION
Fix for: Warning: Failed prop type: The prop `submit` is marked as required in `Login`, but its value is `undefined`.